### PR TITLE
moving fill command so that sf polygons are also plotted with the rig…

### DIFF
--- a/R/emodnet_map_plot.R
+++ b/R/emodnet_map_plot.R
@@ -40,7 +40,6 @@ emodnet_map_plot <- function(data, fill = NULL, title = NULL, subtitle = NULL, l
   if(class(data)[1] == "RasterLayer"){
     message("Transforming RasterLayer to sf vector data")
     data <- sf::st_as_sf(raster::rasterToPolygons(data))
-    fill <- sf::st_drop_geometry(data)[, 1]
   }
 
   # If data is sp
@@ -58,6 +57,7 @@ emodnet_map_plot <- function(data, fill = NULL, title = NULL, subtitle = NULL, l
 
   # if data are sf polygons
   if(sf::st_geometry_type(data, FALSE) == "POLYGON"){
+    fill <- sf::st_drop_geometry(data)[, 1]
     if(plot_polygon_border){
       emodnet_map_plot <- emodnet_map_basic +
         ggplot2::geom_sf(data = data, ggplot2::aes(fill = fill), size = 0.05) +

--- a/R/emodnet_map_plot.R
+++ b/R/emodnet_map_plot.R
@@ -57,7 +57,7 @@ emodnet_map_plot <- function(data, fill = NULL, title = NULL, subtitle = NULL, l
 
   # if data are sf polygons
   if(sf::st_geometry_type(data, FALSE) == "POLYGON"){
-    fill <- sf::st_drop_geometry(data)[, 1]
+    if(is.null(fill))fill <- sf::st_drop_geometry(data)[, 1]
     if(plot_polygon_border){
       emodnet_map_plot <- emodnet_map_basic +
         ggplot2::geom_sf(data = data, ggplot2::aes(fill = fill), size = 0.05) +


### PR DESCRIPTION
Within the emodnet_map_plot routine, there is a command defining the fill variable, used in the plot to determine the filling colours. This command was placed right after the transformation of a raster into an sf object. However, if one wants to plot an sf object, the fill variable was not derived. As I think this only applies to polygons, I have moved it to the part where polygon sfs are plotted. It works for rasters and for sf multipolygon objects (in fact derived from rasters but externally).